### PR TITLE
[feature/link-footer] Add target blank to footer links

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,58 @@
+<footer class="footer text-center bg-dark py-6">
+    <div class="container">
+        <div class="row">
+            <div class="col">
+                <ul class="list-inline">
+                    {{ if .Site.Params.social.rss -}}
+                    <li class="list-inline-item">
+                        {{- with .Site.GetPage "" -}}
+                            {{- with .OutputFormats.Get "RSS" -}}
+                                <a href="{{ .Permalink }}" rel="alternate" target="_blank" type="application/rss+xml" class="icons d-block">
+                                    <span class="fa-stack fa-lg">
+                                        <i class="fa fa-circle fa-stack-2x"></i>
+                                        <i class="fa fa-rss fa-stack-1x fa-inverse"></i>
+                                    </span>
+                                </a>
+                            {{- end -}}
+                        {{- end -}}
+                    </li>
+                    {{- end -}}
+                    {{- if .Site.Params.social.email -}}
+                    <li class="list-inline-item">
+                        <a href="mailto://{{ .Site.Params.social.email }}" target="_blank" class="icons d-block">
+                            <span class="fa-stack fa-lg">
+                                <i class="fa fa-circle fa-stack-2x"></i>
+                                <i class="fa fa-envelope fa-stack-1x fa-inverse"></i>
+                            </span>
+                        </a>
+                    </li>
+                    {{- end -}}
+                    {{- range $name, $path := .Site.Params.social -}}
+                        {{- if and $path (not (in (slice "rss" "email") $name)) -}}
+                        <li class="list-inline-item">
+                            <a href="{{ $path | safeURL }}" target="_blank" class="icons d-block">
+                                <span class="fa-stack fa-lg">
+                                    <i class="fa fa-circle fa-stack-2x"></i>
+                                    <i class="fab fa-{{ $name }} fa-stack-1x fa-inverse"></i>
+                                </span>
+                            </a>
+                        </li>
+                        {{- end -}}
+                    {{- end }}
+                </ul>
+
+                <p class="text-muted">
+                    {{ if .Site.Copyright }}
+                        {{ .Site.Copyright | safeHTML }}
+                    {{ else }}
+                        Copyright &copy; {{ .Site.Title }} {{ now.Year }}
+                    {{ end }}
+                </p>
+
+                <p class="text-muted">
+                Powered by <a href="https://gohugo.io" target="_blank">Hugo</a> with <a href="https://github.com/puresyntax71/hugo-theme-chunky-poster" target="_blank">Chunky Poster</a>.
+                </p>
+            </div>
+        </div>
+    </div>
+</footer>


### PR DESCRIPTION
I've duplicated the footer template and add the target attribute in the footer link in order to open in a new tab.

This branch will be merged to the bcneng-v2 branch