### PR TITLE
Change links pointing to .net to .org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # BcnEng
 
-[BcnEng](http://bcneng.net) is a slack community built around the software engineering community from Barcelona.
+[BcnEng](http://bcneng.org) is a slack community built around the software engineering community from Barcelona.
 
-You can get an invitation to join it [here](http://slack.bcneng.net).
-
+You can get an invitation to join it [here](http://slack.bcneng.org).
 
 ## Developers
+
 This repository hosts the code to build the static website using [Hugo](https://gohugo.io/).
 
 To get started and contribute to its growth, you only need to clone the repository, including its submodules, and fire a `docker run` command.

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://bcneng.net/"
+baseURL = "https://bcneng.org/"
 languageCode = "en-us"
 title = "BCN Engineering"
 description = "The place where the best engineers from BCN talk about IT"

--- a/content/about.md
+++ b/content/about.md
@@ -6,9 +6,9 @@ aliases = ["about-us","about-hugo","contact"]
 author = "Hugo Authors"
 +++
 
-[BcnEng](http://bcneng.net) is a slack community built around the software engineering community from Barcelona.
+[BcnEng](http://bcneng.org) is a slack community built around the software engineering community from Barcelona.
 
-You can get an invitation to join it [here](http://slack.bcneng.net).
+You can get an invitation to join it [here](http://slack.bcneng.org).
 
 Also please read our:
 - [Code of Conduct](coc/README.md)


### PR DESCRIPTION
I created a 302 from slack.bcneng.org to slack.bcneng.net and will take a while to propagate but I think we can already merge this.